### PR TITLE
[Fix] 아이콘 패키지 빌드 오류 수정

### DIFF
--- a/packages/icons/src/components/complete-check.svg.tsx
+++ b/packages/icons/src/components/complete-check.svg.tsx
@@ -9,8 +9,8 @@ const CompleteCheckSVG = forwardRef<SVGSVGElement, IconProps>(
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox={viewBox}
-        width="48px"
-        height="48px"
+        width={ICON_SIZE_MAP[size]}
+        height={ICON_SIZE_MAP[size]}
         fillRule="nonzero"
         aria-label="complete-check icon"
         fill="none"


### PR DESCRIPTION
## 📂 작업 내용

아이콘 패키지에서 새롭게 빌드를 수행하면, 기존 커스텀 tsx 파일들이 롤백되는 현상이 발견되어 수정하였습니다.

### 해결 방식

generate-svg-component.ts 스크립트의 동작 방식은 다음과 같습니다.
- svg 디렉토리에서 모든 svg 파일들을 읽고, 이름과 파일 경로를 매핑 (generateSvgComponentMap)
- 사용하지 않는 컴포넌트들을 제거 (deleteUnusedComponentFiles)
- 새로운 svg 파일이 있다면 새 컴포넌트 생성 (generateComponentFiles)
- 컴포넌트 파일들 export (generateExportFile)

이 중, generateSvgComponentMap에서 잘못된 비교로 인해 모든 컴포넌트들이 삭제되는 현상이 발견되었습니다.
(ex. key-line 과 KeyLine의 비교로 인해 모든 파일들이 사용되지 않는 컴포넌트들로 판단하여 삭제됨)

이로인해 generateComponentFiles에서 컴포넌트 파일들이 이미 존재하는 지 판별하는 조건문이 동작하지 않았습니다.
```typescript
const generateComponentFiles = async (svgComponentMap: SvgComponentMap) => {
  const components: string[] = [];

  // svgComponentMap을 순회하며 컴포넌트 파일 생성
  for (const [componentName, svgFile] of Object.entries(svgComponentMap)) {
    ...

    // 컴포넌트 파일이 이미 존재하면 생성하지 않고 다음 파일로 넘어감
    if (existsSync(componentFilePath)) {
      components.push(componentName);
      continue;
    }

    // SVG 파일을 읽어 컴포넌트 내용 생성
    const svgFilePath = path.resolve(SVG_DIR, svgFile);
    const svgContent = (await fs.readFile(svgFilePath)).toString();
    const componentContent = createComponentContent(componentName, svgContent, svgFile);

    await fs.writeFile(componentFilePath, componentContent);
    components.push(componentName);
  }

  return components;
};
```

그래서 모든 파일들이 조건문을 만족하지 못해 새롭게 컴포넌트가 생성되고 있었습니다.

따라서 deleteUnusedComponentFiles에서 kebab case들 간 비교할 수 있도록 수정하여 문제를 해결하였습니다.

## 📢 리뷰 참고사항

dev/social-login-cw에 종속되어, 이 브랜치의 PR을 우선적으로 해결해야합니다.
